### PR TITLE
User customizable theme CLI option

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,45 @@ markdown-docx -i input.md -o output.docx
 
 If the output file is not specified, it will use the input filename with a `.docx` extension.
 
+### Customizing Output via CLI
+
+**Theme overrides** (inline JSON via `-t`):
+
+```bash
+# Hex color values WITHOUT the # prefix; sizes in points
+markdown-docx -i input.md -t '{"heading1":"2F5597","bodySize":14,"lineSpacing":1.5}'
+```
+
+**Config file** (`-c`) for full control:
+
+```bash
+markdown-docx -i input.md -c my-config.json
+```
+
+Example `my-config.json`:
+
+```json
+{
+  "ignoreImage": false,
+  "math": { "engine": "katex", "libreOfficeCompat": false },
+  "theme": {
+    "heading1": "2F5597",
+    "bodySize": 14,
+    "lineSpacing": 1.5,
+    "linkUnderline": false
+  }
+}
+```
+
+See [`examples/sample-config.json`](./examples/sample-config.json) for a complete list of all configurable properties with their defaults.
+
+For a full property reference from the terminal:
+
+```bash
+markdown-docx help theme    # all theme color/size properties and defaults
+markdown-docx help config   # all config file options and defaults
+```
+
 ## Supported Markdown Features
 
 - Headings (H1-H6)

--- a/bin/help-texts.mjs
+++ b/bin/help-texts.mjs
@@ -1,0 +1,84 @@
+export const HELP_FOOTER = `
+For detailed option help:
+  markdown-docx help theme    All theme color/size properties and their defaults
+  markdown-docx help config   All config file options and their defaults
+`
+
+export const THEME_HELP = `
+markdown-docx theme customization
+──────────────────────────────────
+
+Pass theme overrides as:
+  -t '{"heading1":"2F5597","bodySize":14}'    inline JSON via flag
+  -c config.json                               file with "theme" key inside
+
+All color values are HEX strings WITHOUT the # prefix.
+Size values are in points.
+
+COLORS (hex, no #)             DEFAULT    DESCRIPTION
+  heading1                     2F5597     H1 heading color
+  heading2                     5B9BD5     H2 heading color
+  heading3                     44546A     H3 heading color
+  heading4                     44546A     H4 heading color
+  heading5                     44546A     H5 heading color
+  heading6                     44546A     H6 heading color
+  link                         0563C1     Hyperlink color
+  code                         032F62     Fenced code block text color
+  codespan                     70AD47     Inline code text color
+  codeBackground               f6f6f7     Code block background
+  blockquote                   666666     Blockquote text color
+  blockquoteBackground         F9F9F9     Blockquote background
+  del                          FF0000     Strikethrough text color
+  hr                           D9D9D9     Horizontal rule color
+  html                         4472C4     Inline HTML color
+  tag                          ED7D31     Tag color
+  border                       A5A5A5     Table border color
+  tableHeaderBackground        F2F2F2     Table header background
+
+SIZES & SPACING                DEFAULT    DESCRIPTION
+  heading1Size                 18         H1 font size (pt)
+  heading2Size                 16         H2 font size (pt)
+  heading3Size                 14         H3 font size (pt)
+  heading4Size                 13         H4 font size (pt)
+  heading5Size                 12         H5 font size (pt)
+  heading6Size                 12         H6 font size (pt)
+  bodySize                     12         Body text font size (pt)
+  codeSize                     11         Code block font size (pt)
+  spaceSize                    6          Paragraph spacing (pt)
+  lineSpacing                  1.0        Line spacing multiplier (1.0 = single, 1.5 = 150%)
+
+BOOLEANS                       DEFAULT    DESCRIPTION
+  linkUnderline                true       Whether hyperlinks are underlined
+
+See examples/sample-config.json for a ready-to-use config file.
+`.trim()
+
+export const CONFIG_HELP = `
+markdown-docx config file reference
+─────────────────────────────────────
+
+Use -c <file.json> to load a JSON config file.
+All fields are optional — omit any to use its default.
+
+FIELD                          TYPE       DEFAULT    DESCRIPTION
+  ignoreImage                  boolean    false      Skip all image processing
+  ignoreFootnote               boolean    false      Skip footnote parsing
+  ignoreHtml                   boolean    false      Skip inline HTML parsing
+  gfm                          boolean    true       GitHub Flavored Markdown
+
+  math.engine                  string     "katex"    "katex" or "builtin"
+  math.libreOfficeCompat       boolean    false      Improve LibreOffice OMML rendering
+  math.katexOptions            object     {}         Options passed directly to KaTeX
+
+  theme                        object     {}         Theme overrides
+                                                     Run: markdown-docx help theme
+
+Example config file:
+  {
+    "ignoreImage": false,
+    "math": { "engine": "katex", "libreOfficeCompat": false },
+    "theme": { "heading1": "2F5597", "bodySize": 14, "lineSpacing": 1.5 }
+  }
+
+See examples/sample-config.json for the full list of configurable properties.
+`.trim()

--- a/bin/markdown-docx.mjs
+++ b/bin/markdown-docx.mjs
@@ -4,9 +4,9 @@ import fs from 'node:fs/promises'
 import path from 'node:path'
 import { Command } from 'commander'
 import markdownToDocx, { Packer } from '../dist/index.node.mjs'
+import { HELP_FOOTER, THEME_HELP, CONFIG_HELP } from './help-texts.mjs'
 
 const pkg = JSON.parse(await fs.readFile(new URL('../package.json', import.meta.url), 'utf-8'))
-
 const { name, description, version } = pkg
 
 const program = new Command()
@@ -17,10 +17,41 @@ program
   .version(version, '-v, --version', 'output the version number')
   .option('-i, --input <file>', 'input markdown file')
   .option('-o, --output <file>', 'output docx file')
-  .option('-t, --theme <inline-json>', 'theme overrides as JSON (e.g., \'{"bodySize": 14, "lineSpacing": 1.5}\')')
-  .option('-c, --config <file>', 'JSON file with MarkdownDocxOptions overrides (includes theme, ignoreImage, etc.)')
+  .option('-t, --theme <json>', 'theme overrides as inline JSON (run: markdown-docx help theme)')
+  .option('-c, --config <file>', 'JSON config file with all options (run: markdown-docx help config)')
+
+program
+  .command('help [topic]')
+  .description('Show detailed help for theme or config options (topics: theme, config)')
+  .action((topic) => {
+    if (!topic) {
+      console.log('Available help topics:')
+      console.log('  markdown-docx help theme    Theme color/size properties and defaults')
+      console.log('  markdown-docx help config   Config file structure and all option defaults')
+    } else if (topic === 'theme') {
+      console.log(THEME_HELP)
+    } else if (topic === 'config') {
+      console.log(CONFIG_HELP)
+    } else {
+      process.stderr.write(`Unknown help topic: ${topic}\nAvailable topics: theme, config\n`)
+      process.exit(1)
+    }
+  })
+
+program
   .action(doCommand)
-  .parse(process.argv)
+
+program
+  .parseAsync(process.argv)
+  .catch((err) => {
+    console.error(`\x1b[31mError: ${err.message}\x1b[0m`)
+    if (err.message === 'Input file is required') {
+      program.help()
+    } else {
+      console.error(err.stack)
+    }
+    process.exit(1)
+  })
 
 async function doCommand(options) {
   if (!options.input) {

--- a/bin/markdown-docx.mjs
+++ b/bin/markdown-docx.mjs
@@ -17,6 +17,8 @@ program
   .version(version, '-v, --version', 'output the version number')
   .option('-i, --input <file>', 'input markdown file')
   .option('-o, --output <file>', 'output docx file')
+  .option('-t, --theme <inline-json>', 'theme overrides as JSON (e.g., \'{"bodySize": 14, "lineSpacing": 1.5}\')')
+  .option('-c, --config <file>', 'JSON file with MarkdownDocxOptions overrides (includes theme, ignoreImage, etc.)')
   .action(doCommand)
   .parse(process.argv)
 
@@ -36,12 +38,37 @@ async function doCommand(options) {
     throw new Error(`[${name}] Output file must be a .docx file, but got ${ext}`)
   }
 
+  const markdownDocxOptions = {}
+
+  if (options.config) {
+    try {
+      const configContent = await fs.readFile(options.config, 'utf-8')
+      const baseOptions = JSON.parse(configContent)
+      Object.assign(markdownDocxOptions, baseOptions)
+    } catch (err) {
+      throw new Error(`Failed to load config file "${options.config}": ${err.message}`)
+    }
+  }
+
+  if (!markdownDocxOptions.theme) {
+    markdownDocxOptions.theme = {}
+  }
+
+  if (options.theme) {
+    try {
+      const themeOverride = JSON.parse(options.theme)
+      Object.assign(markdownDocxOptions.theme, themeOverride)
+    } catch (err) {
+      throw new Error(`Failed to parse --theme JSON: ${err.message}`)
+    }
+  }
+
   const content = await fs.readFile(options.input, 'utf-8')
   if (!content) {
     throw new Error(`[${name}] File ${options.input} is empty`)
   }
 
-  const docx = await markdownToDocx(content)
+  const docx = await markdownToDocx(content, markdownDocxOptions)
   const buffer = await Packer.toBuffer(docx)
 
   await fs.writeFile(options.output, buffer)

--- a/examples/sample-config.json
+++ b/examples/sample-config.json
@@ -1,0 +1,42 @@
+{
+  "_note": "All values shown are defaults. Remove or omit any property to use the default. Run 'markdown-docx help theme' or 'markdown-docx help config' for a full reference.",
+  "ignoreImage": false,
+  "ignoreFootnote": false,
+  "ignoreHtml": false,
+  "gfm": true,
+  "math": {
+    "engine": "katex",
+    "libreOfficeCompat": false
+  },
+  "theme": {
+    "heading1": "2F5597",
+    "heading2": "5B9BD5",
+    "heading3": "44546A",
+    "heading4": "44546A",
+    "heading5": "44546A",
+    "heading6": "44546A",
+    "link": "0563C1",
+    "code": "032F62",
+    "codespan": "70AD47",
+    "codeBackground": "f6f6f7",
+    "blockquote": "666666",
+    "blockquoteBackground": "F9F9F9",
+    "del": "FF0000",
+    "hr": "D9D9D9",
+    "html": "4472C4",
+    "tag": "ED7D31",
+    "border": "A5A5A5",
+    "tableHeaderBackground": "F2F2F2",
+    "heading1Size": 18,
+    "heading2Size": 16,
+    "heading3Size": 14,
+    "heading4Size": 13,
+    "heading5Size": 12,
+    "heading6Size": 12,
+    "bodySize": 12,
+    "codeSize": 11,
+    "spaceSize": 6,
+    "lineSpacing": 1.0,
+    "linkUnderline": true
+  }
+}

--- a/src/__snapshots__/index.test.ts.snap
+++ b/src/__snapshots__/index.test.ts.snap
@@ -250,13 +250,13 @@ exports[`render > render list number with table 1`] = `
 <Paragraph numbering-level="0" numbering-reference="numbering-points" numbering-instance="1" style="MdListItem"><TextRun>有序列表项一 — 基本说明</TextRun></Paragraph>
 <Paragraph style="MdSpace"></Paragraph>
 <Paragraph bullet-level="1" style="MdListItem"><TextRun>这是一个子无序项，包含行内代码示例：</TextRun>
-<TextRun style="MdCode" >console.log('hello')</TextRun>
+<TextRun style="MdCodespan" >console.log('hello')</TextRun>
 <TextRun>。</TextRun></Paragraph>
 <Paragraph bullet-level="1" style="MdListItem"><TextRun>下面插入一个表格用于测试表格渲染：</TextRun></Paragraph>
 <Paragraph style="MdSpace"></Paragraph>
-<Table style="MdTable" width-size="100%" width-type="pct" columnWidths="3333.3333333333335,3333.3333333333335,3333.3333333333335" rows="<TableRow tableHeader="true" cantSplit="true"><TableCell verticalAlign="center" shading-fill="F1F2F1"><Paragraph style="MdTableHeader"><TextRun>名称</TextRun></Paragraph></TableCell>
-<TableCell verticalAlign="center" shading-fill="F1F2F1"><Paragraph style="MdTableHeader"><TextRun>类型</TextRun></Paragraph></TableCell>
-<TableCell verticalAlign="center" shading-fill="F1F2F1"><Paragraph style="MdTableHeader"><TextRun>说明</TextRun></Paragraph></TableCell></TableRow>,<TableRow cantSplit="true"><TableCell verticalAlign="center"><Paragraph style="MdTableCell"><TextRun>id</TextRun></Paragraph></TableCell>
+<Table style="MdTable" width-size="100%" width-type="pct" columnWidths="3333.3333333333335,3333.3333333333335,3333.3333333333335" rows="<TableRow tableHeader="true" cantSplit="true"><TableCell verticalAlign="center" shading-fill="F2F2F2"><Paragraph style="MdTableHeader"><TextRun>名称</TextRun></Paragraph></TableCell>
+<TableCell verticalAlign="center" shading-fill="F2F2F2"><Paragraph style="MdTableHeader"><TextRun>类型</TextRun></Paragraph></TableCell>
+<TableCell verticalAlign="center" shading-fill="F2F2F2"><Paragraph style="MdTableHeader"><TextRun>说明</TextRun></Paragraph></TableCell></TableRow>,<TableRow cantSplit="true"><TableCell verticalAlign="center"><Paragraph style="MdTableCell"><TextRun>id</TextRun></Paragraph></TableCell>
 <TableCell verticalAlign="center"><Paragraph style="MdTableCell"><TextRun>int</TextRun></Paragraph></TableCell>
 <TableCell verticalAlign="center"><Paragraph style="MdTableCell"><TextRun>主键，自增</TextRun></Paragraph></TableCell></TableRow>,<TableRow cantSplit="true"><TableCell verticalAlign="center"><Paragraph style="MdTableCell"><TextRun>name</TextRun></Paragraph></TableCell>
 <TableCell verticalAlign="center"><Paragraph style="MdTableCell"><TextRun>string</TextRun></Paragraph></TableCell>
@@ -275,7 +275,7 @@ exports[`render > render list number with table 1`] = `
 <TextRun>、</TextRun>
 <TextRun style="MdStrong" bold="true">粗体</TextRun>
 <TextRun>、</TextRun>
-<TextRun style="MdCode" >代码</TextRun>
+<TextRun style="MdCodespan" >代码</TextRun>
 <TextRun>。</TextRun></Paragraph>
 <Paragraph style="MdSpace"></Paragraph>"
 `;
@@ -335,17 +335,17 @@ exports[`render > render paragraph 1`] = `
 
 exports[`render > render table dev 1`] = `
 "<Paragraph style="MdSpace"></Paragraph>
-<Table style="MdTable" width-size="100%" width-type="pct" columnWidths="3333.3333333333335,3333.3333333333335,3333.3333333333335" rows="<TableRow tableHeader="true" cantSplit="true"><TableCell verticalAlign="center" shading-fill="F1F2F1"><Paragraph style="MdTableHeader"><TextRun>id</TextRun></Paragraph></TableCell>
-<TableCell verticalAlign="center" shading-fill="F1F2F1"><Paragraph style="MdTableHeader"><TextRun>date</TextRun></Paragraph></TableCell>
-<TableCell verticalAlign="center" shading-fill="F1F2F1"><Paragraph style="MdTableHeader"><TextRun>image</TextRun></Paragraph></TableCell></TableRow>,<TableRow cantSplit="true"><TableCell verticalAlign="center"><Paragraph style="MdTableCell"><TextRun>1</TextRun></Paragraph></TableCell>
+<Table style="MdTable" width-size="100%" width-type="pct" columnWidths="3333.3333333333335,3333.3333333333335,3333.3333333333335" rows="<TableRow tableHeader="true" cantSplit="true"><TableCell verticalAlign="center" shading-fill="F2F2F2"><Paragraph style="MdTableHeader"><TextRun>id</TextRun></Paragraph></TableCell>
+<TableCell verticalAlign="center" shading-fill="F2F2F2"><Paragraph style="MdTableHeader"><TextRun>date</TextRun></Paragraph></TableCell>
+<TableCell verticalAlign="center" shading-fill="F2F2F2"><Paragraph style="MdTableHeader"><TextRun>image</TextRun></Paragraph></TableCell></TableRow>,<TableRow cantSplit="true"><TableCell verticalAlign="center"><Paragraph style="MdTableCell"><TextRun>1</TextRun></Paragraph></TableCell>
 <TableCell verticalAlign="center"><Paragraph style="MdTableCell"><TextRun>2025-09-01</TextRun></Paragraph></TableCell>
 <TableCell verticalAlign="center"><Paragraph style="MdTableCell"><ImageRun type="png" transformation-width="104" transformation-height="126" altText-title="标题文字" altText-description="图片" altText-name="图片"></ImageRun></Paragraph></TableCell></TableRow>"></Table>"
 `;
 
 exports[`render > render tables 1`] = `
-"<Table style="MdTable" width-size="100%" width-type="pct" columnWidths="3333.3333333333335,3333.3333333333335,3333.3333333333335" rows="<TableRow tableHeader="true" cantSplit="true"><TableCell verticalAlign="center" shading-fill="F1F2F1"><Paragraph style="MdTableHeader"><TextRun>Tables</TextRun></Paragraph></TableCell>
-<TableCell verticalAlign="center" shading-fill="F1F2F1"><Paragraph alignment="center" style="MdTableHeader"><TextRun>Are</TextRun></Paragraph></TableCell>
-<TableCell verticalAlign="center" shading-fill="F1F2F1"><Paragraph alignment="right" style="MdTableHeader"><TextRun>Cool</TextRun></Paragraph></TableCell></TableRow>,<TableRow cantSplit="true"><TableCell verticalAlign="center"><Paragraph style="MdTableCell"><TextRun>col 3 is</TextRun></Paragraph></TableCell>
+"<Table style="MdTable" width-size="100%" width-type="pct" columnWidths="3333.3333333333335,3333.3333333333335,3333.3333333333335" rows="<TableRow tableHeader="true" cantSplit="true"><TableCell verticalAlign="center" shading-fill="F2F2F2"><Paragraph style="MdTableHeader"><TextRun>Tables</TextRun></Paragraph></TableCell>
+<TableCell verticalAlign="center" shading-fill="F2F2F2"><Paragraph alignment="center" style="MdTableHeader"><TextRun>Are</TextRun></Paragraph></TableCell>
+<TableCell verticalAlign="center" shading-fill="F2F2F2"><Paragraph alignment="right" style="MdTableHeader"><TextRun>Cool</TextRun></Paragraph></TableCell></TableRow>,<TableRow cantSplit="true"><TableCell verticalAlign="center"><Paragraph style="MdTableCell"><TextRun>col 3 is</TextRun></Paragraph></TableCell>
 <TableCell verticalAlign="center"><Paragraph alignment="center" style="MdTableCell"><TextRun>right-aligned</TextRun></Paragraph></TableCell>
 <TableCell verticalAlign="center"><Paragraph alignment="right" style="MdTableCell"><TextRun>$1600</TextRun></Paragraph></TableCell></TableRow>,<TableRow cantSplit="true"><TableCell verticalAlign="center"><Paragraph style="MdTableCell"><TextRun>col 2 is</TextRun></Paragraph></TableCell>
 <TableCell verticalAlign="center"><Paragraph alignment="center" style="MdTableCell"><TextRun>centered</TextRun></Paragraph></TableCell>
@@ -355,10 +355,10 @@ exports[`render > render tables 1`] = `
 `;
 
 exports[`render > render tables special 1`] = `
-"<Table style="MdTable" width-size="100%" width-type="pct" columnWidths="3333.3333333333335,3333.3333333333335,3333.3333333333335" rows="<TableRow tableHeader="true" cantSplit="true"><TableCell verticalAlign="center" shading-fill="F1F2F1"><Paragraph style="MdTableHeader"><TextRun>Markdown</TextRun></Paragraph></TableCell>
-<TableCell verticalAlign="center" shading-fill="F1F2F1"><Paragraph style="MdTableHeader"><TextRun>Less</TextRun></Paragraph></TableCell>
-<TableCell verticalAlign="center" shading-fill="F1F2F1"><Paragraph style="MdTableHeader"><TextRun>Pretty</TextRun></Paragraph></TableCell></TableRow>,<TableRow cantSplit="true"><TableCell verticalAlign="center"><Paragraph style="MdTableCell"><TextRun style="MdEm" italics="true">Still</TextRun></Paragraph></TableCell>
-<TableCell verticalAlign="center"><Paragraph style="MdTableCell"><TextRun style="MdCode" >renders</TextRun></Paragraph></TableCell>
+"<Table style="MdTable" width-size="100%" width-type="pct" columnWidths="3333.3333333333335,3333.3333333333335,3333.3333333333335" rows="<TableRow tableHeader="true" cantSplit="true"><TableCell verticalAlign="center" shading-fill="F2F2F2"><Paragraph style="MdTableHeader"><TextRun>Markdown</TextRun></Paragraph></TableCell>
+<TableCell verticalAlign="center" shading-fill="F2F2F2"><Paragraph style="MdTableHeader"><TextRun>Less</TextRun></Paragraph></TableCell>
+<TableCell verticalAlign="center" shading-fill="F2F2F2"><Paragraph style="MdTableHeader"><TextRun>Pretty</TextRun></Paragraph></TableCell></TableRow>,<TableRow cantSplit="true"><TableCell verticalAlign="center"><Paragraph style="MdTableCell"><TextRun style="MdEm" italics="true">Still</TextRun></Paragraph></TableCell>
+<TableCell verticalAlign="center"><Paragraph style="MdTableCell"><TextRun style="MdCodespan" >renders</TextRun></Paragraph></TableCell>
 <TableCell verticalAlign="center"><Paragraph style="MdTableCell"><TextRun style="MdStrong" bold="true">nicely</TextRun></Paragraph></TableCell></TableRow>,<TableRow cantSplit="true"><TableCell verticalAlign="center"><Paragraph style="MdTableCell"><TextRun>1</TextRun></Paragraph></TableCell>
 <TableCell verticalAlign="center"><Paragraph style="MdTableCell"><TextRun>2</TextRun></Paragraph></TableCell>
 <TableCell verticalAlign="center"><Paragraph style="MdTableCell"><TextRun>3</TextRun></Paragraph></TableCell></TableRow>"></Table>"

--- a/src/__snapshots__/tokenize.test.ts.snap
+++ b/src/__snapshots__/tokenize.test.ts.snap
@@ -677,6 +677,14 @@ exports[`tokenize > parse images 1`] = `
         "raw": "![alt text](https://github.com/adam-p/markdown-here/raw/master/src/common/images/icon48.png "Logo Title Text 1")",
         "text": "alt text",
         "title": "Logo Title Text 1",
+        "tokens": [
+          {
+            "escaped": false,
+            "raw": "alt text",
+            "text": "alt text",
+            "type": "text",
+          },
+        ],
         "type": "image",
       },
     ],
@@ -707,6 +715,14 @@ exports[`tokenize > parse images 1`] = `
         "raw": "![alt text][logo]",
         "text": "alt text",
         "title": "Logo Title Text 2",
+        "tokens": [
+          {
+            "escaped": false,
+            "raw": "alt text",
+            "text": "alt text",
+            "type": "text",
+          },
+        ],
         "type": "image",
       },
     ],
@@ -2394,6 +2410,14 @@ exports[`tokenize > render image size 1`] = `
         "raw": "![Alt text](image.png "600x400")",
         "text": "Alt text",
         "title": "600x400",
+        "tokens": [
+          {
+            "escaped": false,
+            "raw": "Alt text",
+            "text": "Alt text",
+            "type": "text",
+          },
+        ],
         "type": "image",
       },
     ],
@@ -2413,6 +2437,14 @@ exports[`tokenize > render image size 2`] = `
         "raw": "![Alt text](image.png "50%x50%")",
         "text": "Alt text",
         "title": "50%x50%",
+        "tokens": [
+          {
+            "escaped": false,
+            "raw": "Alt text",
+            "text": "Alt text",
+            "type": "text",
+          },
+        ],
         "type": "image",
       },
     ],

--- a/src/extensions/latex.ts
+++ b/src/extensions/latex.ts
@@ -6,7 +6,7 @@ import { mathmlToDocxChildren } from './mathml-to-docx'
 import { MarkdownDocx } from '../MarkdownDocx'
 import { BlockKatex, IExtension, InlineKatex } from './types'
 
-const inlineRule = /^(\${1,2})(?!\$)((?:\\.|[^\\\n])*?(?:\\.|[^\\\n\$]))\1(?=[\s?!\.,:;)\]–—？！。，：-]|$)/;
+const inlineRule = /^(\${1,2})(?!\$)((?:\\.|[^\\\n])*?(?:\\.|[^\\\n\$]))\1(?=[\s?!\.,:;%)\]–—？！。，：-]|$)/;
 const inlineRuleNonStandard = /^(\${1,2})(?!\$)((?:\\.|[^\\\n])*?(?:\\.|[^\\\n\$]))\1/; // Non-standard, even if there are no spaces before and after $ or $$, try to parse
 
 const blockRule = /^(\${1,2})\n((?:\\[^]|[^\\])+?)\n\1(?:\n|$)/;

--- a/src/styles/markdown.ts
+++ b/src/styles/markdown.ts
@@ -11,7 +11,7 @@ export const createMarkdownStyle = (_theme: Partial<IMarkdownTheme>): Record<IMa
     space: {
       className: classes.Space,
       run: {
-        size: theme.spaceSize, // 6pt - small space
+        size: theme.spaceSize * 2, // convert pt to half-points
       },
       paragraph: {
         spacing: {
@@ -24,7 +24,7 @@ export const createMarkdownStyle = (_theme: Partial<IMarkdownTheme>): Record<IMa
       className: classes.Code,
       run: {
         font: "Courier New",
-        size: theme.codeSize, // 11pt
+        size: theme.codeSize * 2, // convert pt to half-points
         color: theme.code,
       },
       paragraph: {
@@ -181,7 +181,7 @@ export const createMarkdownStyle = (_theme: Partial<IMarkdownTheme>): Record<IMa
     heading1: {
       className: classes.Heading1,
       run: {
-        size: theme.heading1Size, // 18pt
+        size: theme.heading1Size * 2, // convert pt to half-points
         bold: true,
         color: theme.heading1,
       },
@@ -197,7 +197,7 @@ export const createMarkdownStyle = (_theme: Partial<IMarkdownTheme>): Record<IMa
     heading2: {
       className: classes.Heading2,
       run: {
-        size: theme.heading2Size, // 16pt
+        size: theme.heading2Size * 2, // convert pt to half-points
         bold: true,
         color: theme.heading2,
       },
@@ -213,7 +213,7 @@ export const createMarkdownStyle = (_theme: Partial<IMarkdownTheme>): Record<IMa
     heading3: {
       className: classes.Heading3,
       run: {
-        size: theme.heading3Size, // 14pt
+        size: theme.heading3Size * 2, // convert pt to half-points
         bold: true,
         color: theme.heading3,
       },
@@ -229,7 +229,7 @@ export const createMarkdownStyle = (_theme: Partial<IMarkdownTheme>): Record<IMa
     heading4: {
       className: classes.Heading4,
       run: {
-        size: theme.heading4Size, // 13pt
+        size: theme.heading4Size * 2, // convert pt to half-points
         bold: true,
         color: theme.heading4,
       },
@@ -245,7 +245,7 @@ export const createMarkdownStyle = (_theme: Partial<IMarkdownTheme>): Record<IMa
     heading5: {
       className: classes.Heading5,
       run: {
-        size: theme.heading5Size, // 12pt
+        size: theme.heading5Size * 2, // convert pt to half-points
         bold: true,
         italics: true,
         color: theme.heading5,
@@ -262,7 +262,7 @@ export const createMarkdownStyle = (_theme: Partial<IMarkdownTheme>): Record<IMa
     heading6: {
       className: classes.Heading6,
       run: {
-        size: theme.heading6Size, // 12pt
+        size: theme.heading6Size * 2, // convert pt to half-points
         bold: false,
         italics: true,
         color: theme.heading6,

--- a/src/styles/styles.ts
+++ b/src/styles/styles.ts
@@ -8,30 +8,39 @@ import {
 
 import { IMarkdownToken, IMarkdownTheme } from '../types'
 import { createMarkdownStyle, markdown } from './markdown'
+import { defaultTheme } from './themes'
 
-export const defaultStyle: IStylesOptions['default'] = {
-  document: {
-    run: {
-      size: 24, // 12pt
+export function createDefaultStyle(theme: IMarkdownTheme): IStylesOptions['default'] {
+  return {
+    document: {
+      run: {
+        size: (theme.bodySize ?? 12) * 2, // Convert pt to half-points
+      },
+      paragraph: {
+        spacing: {
+          line: Math.round((theme.lineSpacing ?? 1.0) * 240), // Convert to twips
+          lineRule: "auto"
+        }
+      }
     },
-    paragraph: {
-      spacing: { lineRule: "auto" }
-    }
-  },
-  hyperlink: {},
-  heading1: {},
-  heading2: {},
-  heading3: {},
-  heading4: {},
-  heading5: {},
-  heading6: {},
-  strong: {},
-  listParagraph: {},
-  footnoteReference: {},
-  footnoteText: {},
-  footnoteTextChar: {},
-  title: {}
+    hyperlink: {},
+    heading1: {},
+    heading2: {},
+    heading3: {},
+    heading4: {},
+    heading5: {},
+    heading6: {},
+    strong: {},
+    listParagraph: {},
+    footnoteReference: {},
+    footnoteText: {},
+    footnoteTextChar: {},
+    title: {}
+  }
 }
+
+// Legacy export for backward compatibility: use defaultTheme as input
+export const defaultStyle = createDefaultStyle(defaultTheme)
 
 type CreateDocumentStyleOptions = {
   theme?: Partial<IMarkdownTheme>
@@ -40,9 +49,10 @@ type CreateDocumentStyleOptions = {
 export function createDocumentStyle({ theme }: CreateDocumentStyleOptions): IStylesOptions {
   const paragraphStyles: IParagraphStyleOptions[] = []
   const characterStyles: ICharacterStyleOptions[] = []
-  const markdownTheme = theme ? createMarkdownStyle(theme) : markdown
+  const mergedTheme = theme ? { ...defaultTheme, ...theme } : defaultTheme
+  const markdownTheme = theme ? createMarkdownStyle(mergedTheme) : markdown
   const keys = Object.keys(markdownTheme) as IMarkdownToken[]
-  const styles = { ...defaultStyle }
+  const styles = { ...createDefaultStyle(mergedTheme) }
   for (const key of keys) {
     const style = markdownTheme[key]
     if (!style) continue

--- a/src/styles/styles.ts
+++ b/src/styles/styles.ts
@@ -14,11 +14,11 @@ export function createDefaultStyle(theme: IMarkdownTheme): IStylesOptions['defau
   return {
     document: {
       run: {
-        size: (theme.bodySize ?? 12) * 2, // Convert pt to half-points
+        size: (theme.bodySize ?? defaultTheme.bodySize) * 2, // Convert pt to half-points
       },
       paragraph: {
         spacing: {
-          line: Math.round((theme.lineSpacing ?? 1.0) * 240), // Convert to twips
+          line: Math.round((theme.lineSpacing ?? defaultTheme.lineSpacing) * 240), // Convert to twips
           lineRule: "auto"
         }
       }

--- a/src/styles/themes.ts
+++ b/src/styles/themes.ts
@@ -26,13 +26,15 @@ export const defaultTheme: IMarkdownTheme = {
   /**
    * Theme Patterns
    */
-  heading1Size: 36,
-  heading2Size: 32,
-  heading3Size: 28,
-  heading4Size: 26,
-  heading5Size: 24,
-  heading6Size: 24,
-  spaceSize: 12,
-  codeSize: 22,
+  heading1Size: 18,
+  heading2Size: 16,
+  heading3Size: 14,
+  heading4Size: 13,
+  heading5Size: 12,
+  heading6Size: 12,
+  bodySize: 12,
+  lineSpacing: 1.0,
+  spaceSize: 6,
+  codeSize: 11,
   linkUnderline: true,
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -208,4 +208,10 @@ export type IMarkdownTheme = {
   codeSize: number
   linkUnderline: boolean
 
+  /**
+   * Body typography customization
+   */
+  bodySize?: number        // Font size in points (e.g., 14 for 14pt). Optional, uses library default if omitted.
+  lineSpacing?: number     // Line spacing multiplier (e.g., 1.5 for 150%). Optional, uses library default if omitted.
+
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,4 @@
-import { Alignment, AlignmentType, HeadingLevel } from 'docx'
+import { AlignmentType, HeadingLevel } from 'docx'
 import { Tokens } from 'marked'
 
 import { IBlockAttr, MarkdownImageType } from './types'

--- a/tests/theme-CLI.test.ts
+++ b/tests/theme-CLI.test.ts
@@ -100,3 +100,53 @@ describe('CLI precedence: --theme overrides --config', () => {
     fs.unlinkSync(configFile)
   })
 })
+
+describe('CLI help subcommand', () => {
+  it('markdown-docx help theme outputs theme property names', () => {
+    const output = execSync('node bin/markdown-docx.mjs help theme', {
+      cwd: '/home/tsehla/projects/other/markdown-docx',
+      encoding: 'utf-8'
+    })
+    expect(output).toContain('heading1')
+    expect(output).toContain('2F5597')
+    expect(output).toContain('bodySize')
+    expect(output).toContain('linkUnderline')
+    expect(output).toContain('sample-config.json')
+  })
+
+  it('markdown-docx help config outputs config field names', () => {
+    const output = execSync('node bin/markdown-docx.mjs help config', {
+      cwd: '/home/tsehla/projects/other/markdown-docx',
+      encoding: 'utf-8'
+    })
+    expect(output).toContain('ignoreImage')
+    expect(output).toContain('ignoreFootnote')
+    expect(output).toContain('math.engine')
+    expect(output).toContain('libreOfficeCompat')
+    expect(output).toContain('sample-config.json')
+  })
+
+  it('markdown-docx help with no topic lists available topics', () => {
+    const output = execSync('node bin/markdown-docx.mjs help', {
+      cwd: '/home/tsehla/projects/other/markdown-docx',
+      encoding: 'utf-8'
+    })
+    expect(output).toContain('theme')
+    expect(output).toContain('config')
+  })
+
+  it('markdown-docx help with unknown topic exits non-zero', () => {
+    let stderr = ''
+    try {
+      execSync('node bin/markdown-docx.mjs help unknown-topic', {
+        cwd: '/home/tsehla/projects/other/markdown-docx',
+        stdio: ['pipe', 'pipe', 'pipe'],
+        encoding: 'utf-8'
+      })
+      throw new Error('Expected non-zero exit')
+    } catch (err: any) {
+      stderr = (err as any).stderr ?? ''
+    }
+    expect(stderr).toContain('Unknown help topic')
+  })
+})

--- a/tests/theme-CLI.test.ts
+++ b/tests/theme-CLI.test.ts
@@ -1,9 +1,10 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 import { execSync } from 'child_process'
 import fs from 'node:fs'
+import os from 'node:os'
 import path from 'node:path'
 
-const tmpDir = '/tmp/markdown-docx-test'
+const tmpDir = path.join(os.tmpdir(), 'markdown-docx-test')
 const inputFile = path.join(tmpDir, 'test.md')
 const outputFile = path.join(tmpDir, 'test.docx')
 
@@ -23,33 +24,25 @@ afterEach(() => {
 describe('CLI --theme flag', () => {
   it('creates docx with --theme JSON for bodySize', () => {
     const themeJson = JSON.stringify({ bodySize: 14 })
-    execSync(`node bin/markdown-docx.mjs --input ${inputFile} --output ${outputFile} --theme '${themeJson}'`, {
-      cwd: '/home/tsehla/projects/other/markdown-docx'
-    })
+    execSync(`node bin/markdown-docx.mjs --input ${inputFile} --output ${outputFile} --theme '${themeJson}'`)
     expect(fs.existsSync(outputFile)).toBe(true)
   })
 
   it('creates docx with --theme JSON for lineSpacing', () => {
     const themeJson = JSON.stringify({ lineSpacing: 1.5 })
-    execSync(`node bin/markdown-docx.mjs --input ${inputFile} --output ${outputFile} --theme '${themeJson}'`, {
-      cwd: '/home/tsehla/projects/other/markdown-docx'
-    })
+    execSync(`node bin/markdown-docx.mjs --input ${inputFile} --output ${outputFile} --theme '${themeJson}'`)
     expect(fs.existsSync(outputFile)).toBe(true)
   })
 
   it('creates docx with --theme JSON containing multiple properties', () => {
     const themeJson = JSON.stringify({ bodySize: 14, lineSpacing: 1.5, heading1: 'FF0000' })
-    execSync(`node bin/markdown-docx.mjs --input ${inputFile} --output ${outputFile} --theme '${themeJson}'`, {
-      cwd: '/home/tsehla/projects/other/markdown-docx'
-    })
+    execSync(`node bin/markdown-docx.mjs --input ${inputFile} --output ${outputFile} --theme '${themeJson}'`)
     expect(fs.existsSync(outputFile)).toBe(true)
   })
 
   it('throws error for invalid JSON in --theme flag', () => {
     expect(() => {
-      execSync(`node bin/markdown-docx.mjs --input ${inputFile} --output ${outputFile} --theme '{"bodySize": invalid}'`, {
-        cwd: '/home/tsehla/projects/other/markdown-docx'
-      })
+      execSync(`node bin/markdown-docx.mjs --input ${inputFile} --output ${outputFile} --theme '{"bodySize": invalid}'`)
     }).toThrow()
   })
 })
@@ -64,9 +57,7 @@ describe('CLI --config flag', () => {
       }
     }))
 
-    execSync(`node bin/markdown-docx.mjs --input ${inputFile} --output ${outputFile} --config ${configFile}`, {
-      cwd: '/home/tsehla/projects/other/markdown-docx'
-    })
+    execSync(`node bin/markdown-docx.mjs --input ${inputFile} --output ${outputFile} --config ${configFile}`)
     expect(fs.existsSync(outputFile)).toBe(true)
 
     fs.unlinkSync(configFile)
@@ -74,9 +65,7 @@ describe('CLI --config flag', () => {
 
   it('throws error for missing config file', () => {
     expect(() => {
-      execSync(`node bin/markdown-docx.mjs --input ${inputFile} --output ${outputFile} --config /nonexistent/config.json`, {
-        cwd: '/home/tsehla/projects/other/markdown-docx'
-      })
+      execSync(`node bin/markdown-docx.mjs --input ${inputFile} --output ${outputFile} --config /nonexistent/config.json`)
     }).toThrow()
   })
 })
@@ -92,9 +81,7 @@ describe('CLI precedence: --theme overrides --config', () => {
     }))
 
     const themeJson = JSON.stringify({ bodySize: 18 })
-    execSync(`node bin/markdown-docx.mjs --input ${inputFile} --output ${outputFile} --config ${configFile} --theme '${themeJson}'`, {
-      cwd: '/home/tsehla/projects/other/markdown-docx'
-    })
+    execSync(`node bin/markdown-docx.mjs --input ${inputFile} --output ${outputFile} --config ${configFile} --theme '${themeJson}'`)
     expect(fs.existsSync(outputFile)).toBe(true)
 
     fs.unlinkSync(configFile)
@@ -104,7 +91,6 @@ describe('CLI precedence: --theme overrides --config', () => {
 describe('CLI help subcommand', () => {
   it('markdown-docx help theme outputs theme property names', () => {
     const output = execSync('node bin/markdown-docx.mjs help theme', {
-      cwd: '/home/tsehla/projects/other/markdown-docx',
       encoding: 'utf-8'
     })
     expect(output).toContain('heading1')
@@ -116,7 +102,6 @@ describe('CLI help subcommand', () => {
 
   it('markdown-docx help config outputs config field names', () => {
     const output = execSync('node bin/markdown-docx.mjs help config', {
-      cwd: '/home/tsehla/projects/other/markdown-docx',
       encoding: 'utf-8'
     })
     expect(output).toContain('ignoreImage')
@@ -128,7 +113,6 @@ describe('CLI help subcommand', () => {
 
   it('markdown-docx help with no topic lists available topics', () => {
     const output = execSync('node bin/markdown-docx.mjs help', {
-      cwd: '/home/tsehla/projects/other/markdown-docx',
       encoding: 'utf-8'
     })
     expect(output).toContain('theme')
@@ -139,7 +123,6 @@ describe('CLI help subcommand', () => {
     let stderr = ''
     try {
       execSync('node bin/markdown-docx.mjs help unknown-topic', {
-        cwd: '/home/tsehla/projects/other/markdown-docx',
         stdio: ['pipe', 'pipe', 'pipe'],
         encoding: 'utf-8'
       })

--- a/tests/theme-CLI.test.ts
+++ b/tests/theme-CLI.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { execSync } from 'child_process'
+import fs from 'node:fs'
+import path from 'node:path'
+
+const tmpDir = '/tmp/markdown-docx-test'
+const inputFile = path.join(tmpDir, 'test.md')
+const outputFile = path.join(tmpDir, 'test.docx')
+
+beforeEach(() => {
+  if (!fs.existsSync(tmpDir)) {
+    fs.mkdirSync(tmpDir, { recursive: true })
+  }
+  fs.writeFileSync(inputFile, '# Test Heading\n\nBody text here.')
+})
+
+afterEach(() => {
+  if (fs.existsSync(outputFile)) {
+    fs.unlinkSync(outputFile)
+  }
+})
+
+describe('CLI --theme flag', () => {
+  it('creates docx with --theme JSON for bodySize', () => {
+    const themeJson = JSON.stringify({ bodySize: 14 })
+    execSync(`node bin/markdown-docx.mjs --input ${inputFile} --output ${outputFile} --theme '${themeJson}'`, {
+      cwd: '/home/tsehla/projects/other/markdown-docx'
+    })
+    expect(fs.existsSync(outputFile)).toBe(true)
+  })
+
+  it('creates docx with --theme JSON for lineSpacing', () => {
+    const themeJson = JSON.stringify({ lineSpacing: 1.5 })
+    execSync(`node bin/markdown-docx.mjs --input ${inputFile} --output ${outputFile} --theme '${themeJson}'`, {
+      cwd: '/home/tsehla/projects/other/markdown-docx'
+    })
+    expect(fs.existsSync(outputFile)).toBe(true)
+  })
+
+  it('creates docx with --theme JSON containing multiple properties', () => {
+    const themeJson = JSON.stringify({ bodySize: 14, lineSpacing: 1.5, heading1: 'FF0000' })
+    execSync(`node bin/markdown-docx.mjs --input ${inputFile} --output ${outputFile} --theme '${themeJson}'`, {
+      cwd: '/home/tsehla/projects/other/markdown-docx'
+    })
+    expect(fs.existsSync(outputFile)).toBe(true)
+  })
+
+  it('throws error for invalid JSON in --theme flag', () => {
+    expect(() => {
+      execSync(`node bin/markdown-docx.mjs --input ${inputFile} --output ${outputFile} --theme '{"bodySize": invalid}'`, {
+        cwd: '/home/tsehla/projects/other/markdown-docx'
+      })
+    }).toThrow()
+  })
+})
+
+describe('CLI --config flag', () => {
+  it('loads theme from config file', () => {
+    const configFile = path.join(tmpDir, 'config.json')
+    fs.writeFileSync(configFile, JSON.stringify({
+      theme: {
+        bodySize: 16,
+        lineSpacing: 2.0
+      }
+    }))
+
+    execSync(`node bin/markdown-docx.mjs --input ${inputFile} --output ${outputFile} --config ${configFile}`, {
+      cwd: '/home/tsehla/projects/other/markdown-docx'
+    })
+    expect(fs.existsSync(outputFile)).toBe(true)
+
+    fs.unlinkSync(configFile)
+  })
+
+  it('throws error for missing config file', () => {
+    expect(() => {
+      execSync(`node bin/markdown-docx.mjs --input ${inputFile} --output ${outputFile} --config /nonexistent/config.json`, {
+        cwd: '/home/tsehla/projects/other/markdown-docx'
+      })
+    }).toThrow()
+  })
+})
+
+describe('CLI precedence: --theme overrides --config', () => {
+  it('--theme flag overrides --config file for same property', () => {
+    const configFile = path.join(tmpDir, 'config.json')
+    fs.writeFileSync(configFile, JSON.stringify({
+      theme: {
+        bodySize: 14,
+        lineSpacing: 1.5
+      }
+    }))
+
+    const themeJson = JSON.stringify({ bodySize: 18 })
+    execSync(`node bin/markdown-docx.mjs --input ${inputFile} --output ${outputFile} --config ${configFile} --theme '${themeJson}'`, {
+      cwd: '/home/tsehla/projects/other/markdown-docx'
+    })
+    expect(fs.existsSync(outputFile)).toBe(true)
+
+    fs.unlinkSync(configFile)
+  })
+})

--- a/tests/theme-styles.test.ts
+++ b/tests/theme-styles.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest'
+import { createDefaultStyle } from '../src/styles/styles'
+import { IMarkdownTheme } from '../src/types'
+import { defaultTheme } from '../src/styles/themes'
+
+describe('createDefaultStyle', () => {
+  it('converts bodySize (pt) to half-points for docx', () => {
+    const theme: IMarkdownTheme = { ...defaultTheme, bodySize: 14 }
+    const style = createDefaultStyle(theme)
+    expect(style.document?.run?.size).toBe(28) // 14pt * 2 = 28 half-points
+  })
+
+  it('converts 12pt to 24 half-points', () => {
+    const theme: IMarkdownTheme = { ...defaultTheme, bodySize: 12 }
+    const style = createDefaultStyle(theme)
+    expect(style.document?.run?.size).toBe(24)
+  })
+
+  it('converts lineSpacing to twips (240 per 1.0)', () => {
+    const theme: IMarkdownTheme = { ...defaultTheme, lineSpacing: 1.5 }
+    const style = createDefaultStyle(theme)
+    expect(style.document?.paragraph?.spacing?.line).toBe(360) // 1.5 * 240 = 360 twips
+  })
+
+  it('converts single spacing (1.0) to 240 twips', () => {
+    const theme: IMarkdownTheme = { ...defaultTheme, lineSpacing: 1.0 }
+    const style = createDefaultStyle(theme)
+    expect(style.document?.paragraph?.spacing?.line).toBe(240)
+  })
+
+  it('converts double spacing (2.0) to 480 twips', () => {
+    const theme: IMarkdownTheme = { ...defaultTheme, lineSpacing: 2.0 }
+    const style = createDefaultStyle(theme)
+    expect(style.document?.paragraph?.spacing?.line).toBe(480)
+  })
+
+  it('preserves lineRule as auto', () => {
+    const theme: IMarkdownTheme = { ...defaultTheme }
+    const style = createDefaultStyle(theme)
+    expect(style.document?.paragraph?.spacing?.lineRule).toBe('auto')
+  })
+
+  it('uses default values when theme values are undefined', () => {
+    // bodySize defaults to 12 (from defaultTheme)
+    const theme: IMarkdownTheme = { ...defaultTheme, bodySize: undefined }
+    const style = createDefaultStyle(theme)
+    expect(style.document?.run?.size).toBe(24) // 12pt default → 24 half-points
+    
+    // lineSpacing defaults to 1.0 (from defaultTheme)
+    const theme2: IMarkdownTheme = { ...defaultTheme, lineSpacing: undefined }
+    const style2 = createDefaultStyle(theme2)
+    expect(style2.document?.paragraph?.spacing?.line).toBe(240) // 1.0 default → 240 twips
+  })
+})


### PR DESCRIPTION
Hey there, its me again💅

- Added a support for changing fonts and colors from CLI inline and with config.json file.

Users are now able to control all previously existing theme parameters one by one, and 2 new ones: body text font size and line spacing


- Help option to read how to do that

- Error handling for when no input file specified - now displays helpful help
<img width="1349" height="539" alt="image" src="https://github.com/user-attachments/assets/57c06ce1-a739-48d7-8495-dabe72879192" />


- Last but not least - further improvement of math formulas stop chars regex (added %)

![before-after-2](https://github.com/user-attachments/assets/d787c0cc-eae6-4bd7-8be6-b87fd1b66e8f)
